### PR TITLE
修复SQL初始化脚本中文乱码

### DIFF
--- a/docker/mysql/init/sys_dicts.sql
+++ b/docker/mysql/init/sys_dicts.sql
@@ -1,3 +1,6 @@
+SET NAMES utf8mb4;
+SET CHARACTER SET utf8mb4;
+
 DROP TABLE IF EXISTS `sys_dicts`;
 
 CREATE TABLE `sys_dicts` (


### PR DESCRIPTION
**Fixes** #93
**问题背景：**
原 `sys_dicts.sql` 脚本在通过 Docker 部署初始化 MySQL 时，由于未明确指定客户端连接字符集，在部分环境下（如 Windows）会导致数据库内中文数据（如“人工智能”、“课程分类”等）显示为乱码。 
**修复方案：**
在脚本头部添加了显式的字符集声明：
```
SET NAMES utf8mb4;
SET CHARACTER SET utf8mb4;
```
**验证情况：**
经本地测试，清空 mysql/data 目录后重新运行`docker-compose -f docker-compose.yml up -d`，本地服务 127.0.0.1:8090 中文显示恢复正常。
